### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/Barsoomx/django-celery-outbox/security/code-scanning/2](https://github.com/Barsoomx/django-celery-outbox/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` used by jobs has only the minimal scopes required. This can be done at the top level of the workflow (applies to all jobs that don’t override it) or per job. Since both `lint` and `test` jobs only need to check out code, the minimal required permission is `contents: read`.

The best fix here is to add a root-level `permissions` section near the top of `.github/workflows/ci.yml`, alongside `name` and `on`, specifying `contents: read`. This avoids repeating configuration on each job and keeps behavior unchanged: both jobs will still be able to use `actions/checkout` to read the repository, and all other GITHUB_TOKEN capabilities (like writing to contents, issues, pull requests, etc.) will be disabled unless explicitly re-enabled in the future. No imports or other code changes are needed; only the YAML workflow file is updated.

Concretely, edit `.github/workflows/ci.yml` by inserting:

```yaml
permissions:
  contents: read
```

between the `name: CI` and the `on:` block (or directly above `jobs:`; either is valid, but placing it after `name` keeps the structure conventional). No additional methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
