### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/Barsoomx/django-celery-outbox/security/code-scanning/1](https://github.com/Barsoomx/django-celery-outbox/security/code-scanning/1)

In general, the fix is to define an explicit `permissions:` block, either at the workflow root (to apply to all jobs) or per job, granting the minimum necessary scopes. For this workflow, the jobs merely check out code, set up Python, install dependencies, and run lint/tests; they do not create releases, comment on PRs, or push changes. Therefore, `contents: read` is sufficient and aligns with CodeQL’s suggested minimal permissions.

The best fix without changing existing functionality is to add a single `permissions:` block at the top level of `.github/workflows/ci.yml`, alongside `name` and `on`, so it applies to both `lint` and `test` jobs. We set `contents: read`, which allows `actions/checkout` to read the repository while denying write access. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block. No imports or additional methods are needed, since this is purely a configuration change within the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
